### PR TITLE
Ubuntu 18 Bionic Beaver Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,14 @@ env:
   - SITE_HOSTS='dev.drup.devshop.travis dev.projectname.devshop.travis live.projectname.devshop.travis testenv.drpl8.devshop.travis dev.rootproject.devshop.local.computer'
 
   matrix:
-  - test="Ansible on Ubuntu 14.04 Apache"
+  - test="Ubuntu 14.04 Apache"
     COMMAND="bin/robo up --mode=install.sh --test"
 
-  - test="Ansible on Ubuntu 16.04 Apache"
+  - test="Ubuntu 16.04 Apache"
     COMMAND='bin/robo up --mode=install.sh --install-sh-image=geerlingguy/docker-ubuntu1604-ansible --test'
+
+  - test="Ubuntu 18.04 Apache"
+    COMMAND='robo up --mode=install.sh --install-sh-image=geerlingguy/docker-ubuntu1804-ansible --test'
 
   #  - test="Install with Ansible on Ubuntu 14.04 with NGINX"
   #    COMMAND="robo up --mode=install.sh --test --install-sh-options='--server-webserver=nginx'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ before_install:
 - cd ..
 - git clone http://github.com/opendevshop/devshop
 - cd devshop
+- git checkout $DEVSHOP_VERSION
 
 # Prepare devshop CLI.
 - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     COMMAND='bin/robo up --mode=install.sh --install-sh-image=geerlingguy/docker-ubuntu1604-ansible --test'
 
   - test="Ubuntu 18.04 Apache"
-    COMMAND='robo up --mode=install.sh --install-sh-image=geerlingguy/docker-ubuntu1804-ansible --test'
+    COMMAND='bin/robo up --mode=install.sh --install-sh-image=geerlingguy/docker-ubuntu1804-ansible --test'
 
   #  - test="Install with Ansible on Ubuntu 14.04 with NGINX"
   #    COMMAND="robo up --mode=install.sh --test --install-sh-options='--server-webserver=nginx'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 env:
   global:
   - ANSIBLE_ROLE_NAME=opendevshop.devmaster
-  - DEVSHOP_VERSION=1.x
+  - DEVSHOP_VERSION=role-updates
   - SITE_HOSTS='dev.drup.devshop.travis dev.projectname.devshop.travis live.projectname.devshop.travis testenv.drpl8.devshop.travis dev.rootproject.devshop.local.computer'
 
   matrix:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,5 @@
 ---
 
-- hostname: name={{ server_hostname }}
-
-- name: Include OS-specific variables.
-  include_vars: "vars.{{ ansible_os_family }}.yml"
-
 - name: Install extra packages
   apt:
     pkg: "{{ item }}"
@@ -12,6 +7,11 @@
     update_cache: yes
   when: ansible_os_family == "Debian"
   with_items: '{{ extra_packages }}'
+
+- hostname: name={{ server_hostname }}
+
+- name: Include OS-specific variables.
+  include_vars: "vars.{{ ansible_os_family }}.yml"
 
 - name: Install extra packages
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Include OS-specific variables.
+  include_vars: "vars.{{ ansible_os_family }}.yml"
+
 - name: Install extra packages
   apt:
     pkg: "{{ item }}"
@@ -8,17 +11,14 @@
   when: ansible_os_family == "Debian"
   with_items: '{{ extra_packages }}'
 
-- hostname: name={{ server_hostname }}
-
-- name: Include OS-specific variables.
-  include_vars: "vars.{{ ansible_os_family }}.yml"
-
 - name: Install extra packages
   yum:
     name: "{{ item }}"
     state: present
   when: ansible_os_family == "RedHat"
   with_items: '{{ extra_packages }}'
+
+- hostname: name={{ server_hostname }}
 
 - name: Install Drush
   get_url:

--- a/vars/vars.Debian.yml
+++ b/vars/vars.Debian.yml
@@ -12,3 +12,4 @@ extra_packages:
   - postfix
   - cron
   - zip
+  - dbus


### PR DESCRIPTION
Ubuntu 18 support is almost working. The hostname cannot be set inside containers unless the "dbus" package is there. I had hacked in an apt-get install dbus in `Robofile.php` but that seems silly. 

Let's just install dbus?