### PR TITLE
Use DevShop CLI BIN path for all relevant executables.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ php_date_timezone: "America/New_York"
 devshop_version: 1.x
 devshop_cli_version: "{{ devshop_version }}"
 
-devmaster_install_command: "{{ local_bin_path }}/drush hostmaster-install -y --strict=0 {{ server_hostname }} \
+devmaster_install_command: "{{ drush_bin_path }} hostmaster-install -y --strict=0 {{ server_hostname }} \
                                 --aegir_db_host={{ aegir_db_host }} \
                                 --aegir_db_pass={{ mysql_root_password }} \
                                 --aegir_db_port=3306 \

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,7 +57,7 @@ devmaster_install_command: "{{ drush_bin_path }} hostmaster-install -y --strict=
                                 {{ devshop_working_copy }} \
 "
 
-devmaster_upgrade_command: "{{ local_bin_path }}/devshop devmaster:upgrade {{ devshop_version }} --makefile={{ devshop_makefile }} -n --run-from-playbooks"
+devmaster_upgrade_command: "{{ devshop_cli_bin_path }}/devshop devmaster:upgrade {{ devshop_version }} --makefile={{ devshop_makefile }} -n --run-from-playbooks"
 
 # If your system does not allow root user in "sudo" group, change this to "su"
 ansible_become_method_aegir: sudo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ devshop_devmaster_email: admin@local.devshop.site
 devshop_cli_repo: http://github.com/opendevshop/devshop.git
 devshop_cli_update: yes
 devshop_cli_path: /usr/share/devshop
+devshop_cli_bin_path: "{{ devshop_cli_path }}/bin"
+drush_bin_path: "{{ devshop_cli_bin_path }}/drush"
+
 devshop_devmaster_path: "{{ aegir_user_home }}/devmaster-{{ devshop_version }}"
 
 devshop_makefile: "{{ devshop_cli_path }}/build-devmaster.make"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,13 +24,13 @@
     content: 'PATH=$PATH:{{ devshop_cli_path }}/bin'
 
 - name: Check drush status
-  command: "{{ local_bin_path }}/drush status"
+  command: "{{ drush_bin_path }} status"
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"
 
 - name: Clear drush caches
-  command: "{{ local_bin_path }}/drush cache-clear drush"
+  command: "{{ drush_bin_path }} cache-clear drush"
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"
@@ -55,13 +55,6 @@
   args:
     chdir: "{{ devshop_cli_path }}"
 
-- name: Setup devshop CLI executable
-  file:
-    src: "{{ devshop_cli_path }}/bin/devshop"
-    dest: "{{ local_bin_path }}/devshop"
-    state: link
-    force: yes
-
 - name: Create /var/aegir/.drush
   file:
     path: "{{ aegir_user_home }}/.drush"
@@ -71,20 +64,20 @@
     state: directory
 
 - name: Install required drush packages.
-  command: "{{ local_bin_path }}/drush dl {{ item.key }}-{{ item.value }} --destination={{ aegir_user_home }}/.drush/commands --package-handler={{ drush_dl_method }} -y"
+  command: "{{ drush_bin_path }} dl {{ item.key }}-{{ item.value }} --destination={{ aegir_user_home }}/.drush/commands --package-handler={{ drush_dl_method }} -y"
   with_dict: "{{ devshop_drush_packages }}"
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"
 
 - name: Setup Drush Bash Enhancements
-  command: "{{ local_bin_path }}/drush init --yes"
+  command: "{{ drush_bin_path }} init --yes"
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"
 
 - name: Clear the drush cache.
-  command: "{{ local_bin_path }}/drush cc drush"
+  command: "{{ drush_bin_path }} cc drush"
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"
@@ -139,24 +132,24 @@
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"
-  command: "{{ local_bin_path }}/drush @hostmaster vset devshop_support_license_key {{ devshop_support_license_key }}"
+  command: "{{ drush_bin_path }} @hostmaster vset devshop_support_license_key {{ devshop_support_license_key }}"
   when: devshop_support_license_key != ""
 
 - name: DevShop.Support | Validate License Key to setup support modules.
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"
-  command: "{{ local_bin_path }}/drush @hostmaster hosting-devshop_support -v"
+  command: "{{ drush_bin_path }} @hostmaster hosting-devshop_support -v"
   when: devshop_support_license_key != ""
 
 - name: Ensure hosting-dispatch crontab is setup
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"
-  command: "{{ local_bin_path }}/drush @hostmaster hosting-setup -y"
+  command: "{{ drush_bin_path }} @hostmaster hosting-setup -y"
 
 - name: Save SSH key as variable
-  shell: "{{ local_bin_path }}/drush @hostmaster vset devshop_public_key \"$(cat ~/.ssh/id_rsa.pub)\" --yes"
+  shell: "{{ drush_bin_path }} @hostmaster vset devshop_public_key \"$(cat ~/.ssh/id_rsa.pub)\" --yes"
   become: yes
   become_user: aegir
   become_method: "{{ ansible_become_method_aegir }}"
@@ -187,7 +180,7 @@
   become_method: "{{ ansible_become_method_aegir }}"
 
 - name: Clear the drush cache.
-  command: "{{ local_bin_path }}/drush cc drush"
+  command: "{{ drush_bin_path }} cc drush"
   become: yes
   become_user: "{{ aegir_user_name }}"
   become_method: "{{ ansible_become_method_aegir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,12 +18,10 @@
 
 - hostname: name={{ server_hostname }}
 
-- name: Setup drush CLI executable
-  file:
-    src: "{{ devshop_cli_path }}/bin/drush"
-    dest: "{{ local_bin_path }}/drush"
-    state: link
-    force: yes
+- name: Add DevShop bin directory to Path
+    copy:
+      dest: /etc/profile.d/custom-path.sh
+      content: 'PATH=$PATH:{{ devshop_cli_path }}/bin'
 
 - name: Check drush status
   command: "{{ local_bin_path }}/drush status"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,9 +19,9 @@
 - hostname: name={{ server_hostname }}
 
 - name: Add DevShop bin directory to Path
-    copy:
-      dest: /etc/profile.d/custom-path.sh
-      content: 'PATH=$PATH:{{ devshop_cli_path }}/bin'
+  copy:
+    dest: /etc/profile.d/devshop-cli-path.sh
+    content: 'PATH=$PATH:{{ devshop_cli_path }}/bin'
 
 - name: Check drush status
   command: "{{ local_bin_path }}/drush status"

--- a/templates/hosting-queue-runner.j2
+++ b/templates/hosting-queue-runner.j2
@@ -1,2 +1,2 @@
 #!/bin/bash
-{{ local_bin_path }}/drush @hostmaster hosting-queued
+{{ drush_bin_path }} @hostmaster hosting-queued


### PR DESCRIPTION
If we use the devshop CLI bin path, we can manage things like drush version in composer.json!